### PR TITLE
Refactor: remove the blue highlight of buttons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="description" content="the anti-procrastination to-do list" />
     <meta keywords="productivity, procrastination, tasks, to-do, lists" />
     <link rel="icon" type="image/x-icon" href="/favicon-default.ico" />
+    <link rel="stylesheet" href="style.css">
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/style.css
+++ b/style.css
@@ -1,0 +1,7 @@
+input,
+textarea,
+button,
+select,
+a {
+  -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
Hey @LukeberryPi ,

I removed the blue highlight of buttons on mobile. When you press a button, the blue highlight stays on the button and it's annoying, not least because it's square whereas the button is rounded.