### PR TITLE
fix: theme flickering on reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,20 @@
     <meta name="twitter:title" content="phived" />
     <meta name="twitter:description" content="the anti-procrastination to-do list" />
     <meta name="twitter:image" content="https://www.phived.com/share-banner.png" />
+    <script>
+      /* This script is an optimized copy of helpers/theme.ts 
+         However since it will be blocking the render of the page, 
+         no imports should be here to make this script run as fast as possible.
+      */
+
+      if (localStorage.getItem("theme") === "dark") {
+          document.documentElement.classList.add("dark");
+          localStorage.setItem("theme", "dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+        localStorage.setItem("theme", "light");
+      }
+    </script>
   </head>
   <body class="h-full w-full">
     <div class="h-full w-full" id="root"></div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,23 +1,16 @@
 import { useEffect, useState } from "react";
+import { handleSetTheme, isThemeSetToDark } from "src/utils/helpers/theme";
 import { HeaderProps } from "./Header.types";
 
 export const Header = ({ clearTasks }: HeaderProps) => {
-  const [darkMode, setDarkMode] = useState(
-    localStorage.getItem("darkMode") === "dark" ? true : false
-  );
+  const [isDarkMode, setIsDarkMode] = useState(isThemeSetToDark());
 
   useEffect(() => {
-    if (darkMode) {
-      document.documentElement.classList.add("dark");
-      localStorage.setItem("darkMode", "dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-      localStorage.setItem("darkMode", "light");
-    }
-  }, [darkMode]);
+    handleSetTheme(isDarkMode);
+  }, [isDarkMode]);
 
   const toggleDarkMode = () => {
-    setDarkMode(!darkMode);
+    setIsDarkMode(currentDarkMode => !currentDarkMode);
   };
 
   return (
@@ -27,7 +20,7 @@ export const Header = ({ clearTasks }: HeaderProps) => {
           onClick={toggleDarkMode}
           className="h-10 select-none rounded-2xl px-3 text-base font-medium text-darkerBlack transition duration-100 hover:bg-darkBlack hover:text-lighterWhite hover:ease-in dark:text-lighterWhite dark:hover:bg-lightWhite dark:hover:text-darkBlack xs:text-lg sm:px-4"
         >
-          {darkMode ? "light" : "dark"} mode
+          {isDarkMode ? "light" : "dark"} mode
         </button>
         <button
           onClick={clearTasks}

--- a/src/utils/helpers/theme.ts
+++ b/src/utils/helpers/theme.ts
@@ -1,0 +1,13 @@
+export function isThemeSetToDark() {
+  return localStorage.getItem("theme") === "dark"
+}
+
+export function handleSetTheme(isDarkMode: boolean) {
+  if (isDarkMode) {
+    document.documentElement.classList.add("dark");
+    localStorage.setItem("theme", "dark");
+  } else {
+    document.documentElement.classList.remove("dark");
+    localStorage.setItem("theme", "light");
+  }
+}


### PR DESCRIPTION
Closes #17

## Decisions for this PR
- There is no real elegant way of solving this problem. So there must be a script tag blocking the first render.
- Creates a module for the switching theme logic to be centered.

## Drawbacks
- For a couple of milliseconds the page is having its render blocked.
- There is now a pice of duplicated logic that needs to always be in sync with the related modules update.

## Advantages
- User does not see a flash/flick on the page when loading/reloading it.