### PR TITLE
Uses React-Helmet for stateful head changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-helmet-async": "^1.3.0"
       },
       "devDependencies": {
         "@types/node": "^18.14.6",
@@ -330,6 +331,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1383,6 +1395,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1576,6 +1596,14 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1838,6 +1866,16 @@
         }
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1893,6 +1931,32 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
+      "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
+    },
+    "node_modules/react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -1922,6 +1986,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -2005,6 +2074,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-helmet-async": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^18.14.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,9 @@
-import { useEffect } from "react";
-import { Footer, Header, Logo, Tasks } from "src/components";
+import { HelmetProvider } from "react-helmet-async";
+import { Footer, Header, Logo, Tasks, Head } from "src/components";
 import { useLocalStorage } from "src/hooks";
 
 export default function App() {
   const [tasks, setTasks] = useLocalStorage("persistentTasks", Array(5).fill(""));
-
-  useEffect(() => {
-    const icon = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
-    const title = document.querySelector("title") as HTMLTitleElement;
-    if (tasks.some((task) => !!task)) {
-      icon.href = "/favicon-alert.ico";
-      title.innerText = `[${tasks.filter((task) => !!task).length}] phived`;
-    } else {
-      icon.href = "/favicon-default.ico";
-      title.innerText = "phived";
-    }
-  }, [tasks]);
 
   const clearTasks = () => {
     setTasks(tasks.map((task) => ""));
@@ -23,6 +11,9 @@ export default function App() {
 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center bg-lightWhite selection:bg-berryBlue dark:bg-darkerBlack dark:selection:bg-purpleRain">
+      <HelmetProvider>
+        <Head tasks={tasks} />
+      </HelmetProvider>
       <Header clearTasks={clearTasks} />
       <Tasks tasks={tasks} setTasks={setTasks} />
       <Logo />

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -1,0 +1,25 @@
+import { Helmet } from "react-helmet-async"
+import { HeadProps } from "./Head.types";
+import { useEffect, useState } from "react";
+
+export const Head = ({ tasks }: HeadProps) => {
+  const [title, setTitle] = useState("phived");
+  const [icon, setIcon] = useState("/favicon-default.ico");
+
+  useEffect(() => {
+    if (tasks.some((task) => !!task)) {
+      setIcon("/favicon-alert.ico");
+      setTitle(`[${tasks.filter((task) => !!task).length}] phived`);
+    } else {
+      setIcon("/favicon-default.ico");
+      setTitle("phived");
+    }
+  }, [tasks]);
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <link rel="icon" type="image/x-icon" href={icon} />
+    </Helmet>
+  )
+}

--- a/src/components/Head/Head.types.ts
+++ b/src/components/Head/Head.types.ts
@@ -1,0 +1,3 @@
+export type HeadProps = {
+  tasks: string[];
+}

--- a/src/components/Head/index.ts
+++ b/src/components/Head/index.ts
@@ -1,0 +1,1 @@
+export { Head } from "./Head"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { Footer } from "./Footer";
 export { Header } from "./Header";
 export { Logo } from "./Logo";
 export { Tasks } from "./Tasks";
+export { Head } from "./Head";


### PR DESCRIPTION
## What problem the PR solves?
Previously, head components were being picked inside `App` using querySelector, which is more of a pure Javascript practice than a React one. Because it needs assertions for Typescript integration and also executes the query for every re-render.

## What solution the PR gives?
It uses [react-helmet-async](https://www.npmjs.com/package/react-helmet-async), a library to change `<head>` tags dynamically by accepting stateful approaches. It replaces the original tags with the new ones at any given time when re-renders are performed. 

The PR creates a `Head.tsx` component, that as the name suggests, updates head tags like the title and icon using react states.