### PR TITLE
fix(Tasks): mobile -> prevent click on hidden 'done' from deleting task

### DIFF
--- a/src/components/Tasks/Tasks.tsx
+++ b/src/components/Tasks/Tasks.tsx
@@ -79,7 +79,7 @@ export function Tasks({ tasks, setTasks }: TasksProps) {
           className={`${isFirstTask ? "rounded-tr-2xl" : ""} ${
             isLastTask ? "rounded-br-2xl" : ""
           } ${
-            isEmptyTask ? "hidden" : "group-hover:flex"
+            isEmptyTask ? "hidden" : "max-lg:active:flex max-lg:peer-focus:flex lg:group-hover:flex"
           } hidden w-36 cursor-pointer items-center justify-center border-l border-b bg-berryBlue text-base dark:bg-purpleRain dark:text-lighterWhite xs:text-lg`}
         >
           done?


### PR DESCRIPTION
Closes #29

## What does this PR fix?

There is an unexpected behavior in mobile screens that allow users to delete a task with a single click on the area occupied by a hidden 'done' span. Apparently, it happens because `:hover` is triggered before the click event reaches the span, triggering the eventListener, like the steps below:

- User clicks the area occupied by "done" (which has a `display: none` at this moment);
- `:hover` is triggered and display is changed to `flex`;
- Click event reaches the span and eventListener deletes the task.

## How does this PR fix the problem?

By adding a small combination of Tailwind classes to the "done" span:

- `lg:group-hover:flex` - limits `:hover` to large screens (breakpoint = 1024px);
- `max-lg:peer-focus:flex` - makes "done" visible if its input sibling is focused, but only for screens smaller than lg;
- `max-lg:active:flex` - prevents the following scenario: clicking "done" removes focus from the input and cancels the condition for the class above, then "done" is hidden before the eventListener is triggered and no task is deleted.

Modifications were manually tested in PC and mobile.