### PR TITLE
improvement: drag icon and button visible when dragging

### DIFF
--- a/src/components/Tasks/Tasks.tsx
+++ b/src/components/Tasks/Tasks.tsx
@@ -113,7 +113,9 @@ export function Tasks() {
                   isEmptyTask || tasksLength <= 1
                     ? "hidden"
                     : "max-lg:active:flex max-lg:peer-focus:flex lg:group-hover:flex"
-                } flex hidden items-center justify-center bg-lighterWhite pr-2 text-base text-darkerBlack placeholder:select-none dark:bg-darkBlack dark:text-lighterWhite xs:text-lg`}
+                } ${
+                  !isDragging && "hidden"
+                } flex items-center justify-center bg-lighterWhite pr-2 text-base text-darkerBlack placeholder:select-none dark:bg-darkBlack dark:text-lighterWhite xs:text-lg`}
                 {...provided.dragHandleProps}
                 tabIndex={-1}
               >
@@ -127,7 +129,9 @@ export function Tasks() {
                   isEmptyTask
                     ? "hidden"
                     : "max-lg:active:flex max-lg:peer-focus:flex lg:group-hover:flex"
-                } hidden w-36 cursor-pointer items-center justify-center border-l border-b bg-berryBlue text-base dark:bg-purpleRain dark:text-lighterWhite xs:text-lg`}
+                } ${
+                  !isDragging && "hidden"
+                } w-36 cursor-pointer items-center justify-center border-l border-b bg-berryBlue text-base dark:bg-purpleRain dark:text-lighterWhite xs:text-lg`}
               >
                 done?
               </button>


### PR DESCRIPTION
When dragging a task on larger screens, the dragging button and the "done" button hide. Added conditional to avoid this behaviour 