### PR TITLE
feat: add lib to help with import ordering of dependencies 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "plugins": ["react", "@typescript-eslint", "prettier", "eslint-plugin-import-helpers"],
   "rules": {
     "prettier/prettier": [
       "error",
@@ -39,6 +39,7 @@
     "arrow-body-style": ["error", "as-needed"],
     "react/react-in-jsx-scope": "off",
     "react/self-closing-comp": ["error", { "component": true, "html": true }],
+    "@typescript-eslint/semi": ["error", "always"],
     "no-restricted-imports": [
       "error",
       {
@@ -51,7 +52,6 @@
         "prefer": "type-imports"
       }
     ],
-    "@typescript-eslint/semi": ["error", "always"],
     "@typescript-eslint/member-delimiter-style": [
       "error",
       {
@@ -64,6 +64,25 @@
           "requireLast": false
         },
         "multilineDetection": "brackets"
+      }
+    ],
+    "import-helpers/order-imports": [
+      "warn",
+      {
+          "newlinesBetween": "always",
+          "alphabetize": { "order": "asc", "ignoreCase": true },
+          "groups": [
+            "/^react/",
+            "module",
+            ["/^vite/", "/^@vite/"],
+            "/^src/components/",
+            "/^src/contexts/",
+            "/^src/hooks/",
+            "/^src/utils/",
+            "/^src/content/",
+            "/^src/",
+            ["parent", "sibling", "index"]
+          ]
       }
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "esbuild": "^0.17.12",
         "eslint": "^8.36.0",
         "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import-helpers": "^1.3.1",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -3690,6 +3691,15 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import-helpers": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.3.1.tgz",
+      "integrity": "sha512-MrACDozK6TmTJoCFHD71Ew3r5210Za3zlTrhX+fQGsyvxceaFvAI9AcvZ/8oSU0pZ61G3nDEn6mXY0T4S8cJEg==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": "5.x - 8.x"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "esbuild": "^0.17.12",
     "eslint": "^8.36.0",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import-helpers": "^1.3.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { HelmetProvider } from "react-helmet-async";
+
 import { Footer, Header, Message, Tasks, Head } from "src/components";
 
 export default function App() {

--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from "react-helmet-async";
+
 import { useTasksContext } from "src/contexts";
 
 const headConstants = {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
-import { useTasksContext } from "src/contexts";
+
 import { Logo } from "src/components/Logo";
+
+import { useTasksContext } from "src/contexts";
+
 import { handleSetTheme, isThemeSetToDark } from "src/utils";
 
 export function Header() {

--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -1,9 +1,12 @@
 import { useMemo, useState } from "react";
-import { placeholders } from "src/content";
-import { useTasksContext } from "src/contexts";
 import type { DropResult } from "react-beautiful-dnd";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+
 import { DragIcon } from "src/components/icons/DragIcon";
+
+import { useTasksContext } from "src/contexts";
+
+import { placeholders } from "src/content";
 
 export function Tasks() {
   const { tasks, changeTask, completeTask, setTasks } = useTasksContext();

--- a/src/contexts/TasksContext/TasksContext.ts
+++ b/src/contexts/TasksContext/TasksContext.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+
 import type { TaskContextType } from "src/contexts/TasksContext/TasksContext.types";
 
 export const initialState = {

--- a/src/contexts/TasksContext/TasksContextProvider.tsx
+++ b/src/contexts/TasksContext/TasksContextProvider.tsx
@@ -1,9 +1,12 @@
 import type { PropsWithChildren } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { incentives } from "src/content";
+
 import { TasksContext } from "src/contexts/TasksContext/TasksContext";
 import type { Task } from "src/contexts/TasksContext/TasksContext.types";
+
 import { useLocalStorage } from "src/hooks/useLocalStorage";
+
+import { incentives } from "src/content";
 
 export const TasksContextProvider = ({ children }: PropsWithChildren) => {
   const [storedTasks, setStoredTasks] = useLocalStorage(

--- a/src/index.css
+++ b/src/index.css
@@ -5,5 +5,6 @@
 input {
   -webkit-appearance: none;
   /* we need this to have decent input borders on iOS, ignore warning */
+  border-radius: 0;
   -webkit-border-radius: 0px;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "src/App";
-import "src/index.css";
+
 import { TasksContextProvider } from "src/contexts";
+
+import App from "src/App";
+
+import "src/index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,7 @@
 /* eslint-disable */
 /** @type {import('tailwindcss').Config} */
+/** @type {import('tailwindcss/defaultTheme')} */
+
 const defaultTheme = require("tailwindcss/defaultTheme");
 
 module.exports = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import { VitePWA } from "vite-plugin-pwa";
 import path from "path";
+
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { VitePWA } from "vite-plugin-pwa";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/vite.config.ts.timestamp-1679348897080.mjs
+++ b/vite.config.ts.timestamp-1679348897080.mjs
@@ -1,6 +1,6 @@
 // vite.config.ts
-import { defineConfig } from "file:///D:/LukeberryPi/repos/phived/node_modules/vite/dist/node/index.js";
 import react from "file:///D:/LukeberryPi/repos/phived/node_modules/@vitejs/plugin-react/dist/index.mjs";
+import { defineConfig } from "file:///D:/LukeberryPi/repos/phived/node_modules/vite/dist/node/index.js";
 import path from "path";
 var vite_config_default = defineConfig({
   plugins: [react()],


### PR DESCRIPTION
# Explanation

I added a lib to we don't worry about import ordering of dependencies.

I don't know if you want that to the project, some people like imports all together, has config in lib if you want all together :smile:

[Link of lib](https://www.npmjs.com/package/eslint-plugin-import-helpers)

# Checklist
- [x] Add plugin in eslint to import ordering
- [x] Add border-radius in index.css to solve lint warning
- [x] Add type import of defaultTheme in tailwind.config.cjs