### PR TITLE
feat: add confirmation step to clear tasks

### DIFF
--- a/src/contexts/TasksContext/TasksContextProvider.tsx
+++ b/src/contexts/TasksContext/TasksContextProvider.tsx
@@ -56,7 +56,7 @@ export const TasksContextProvider = ({ children }: PropsWithChildren) => {
   );
 
   const clearTasks = useCallback(() => {
-    const isUserCertain = confirm("do you want to delete all your tasks?");
+    const isUserCertain = confirm("this will delete all your tasks?");
 
     if (!isUserCertain) {
       return;

--- a/src/contexts/TasksContext/TasksContextProvider.tsx
+++ b/src/contexts/TasksContext/TasksContextProvider.tsx
@@ -56,6 +56,12 @@ export const TasksContextProvider = ({ children }: PropsWithChildren) => {
   );
 
   const clearTasks = useCallback(() => {
+    const isUserCertain = confirm("do you want to DELETE all yours tasks?");
+
+    if (!isUserCertain) {
+      return;
+    }
+
     setTasks(Array(5).fill(""));
     displayMessage("tasks cleared!");
   }, [displayMessage, setTasks]);

--- a/src/contexts/TasksContext/TasksContextProvider.tsx
+++ b/src/contexts/TasksContext/TasksContextProvider.tsx
@@ -56,7 +56,7 @@ export const TasksContextProvider = ({ children }: PropsWithChildren) => {
   );
 
   const clearTasks = useCallback(() => {
-    const isUserCertain = confirm("do you want to DELETE all yours tasks?");
+    const isUserCertain = confirm("do you want to delete all your tasks?");
 
     if (!isUserCertain) {
       return;


### PR DESCRIPTION
users have raised concerns about the "clear tasks" button being dangerously easy to press on accident, since it is a destructive action.

this adds a simple confirm dialog to reassure the user of the intended result.