### PR TITLE
Add stopgap fix for safari resize

### DIFF
--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -26,8 +26,8 @@ export function Tasks() {
   const [taskComponentWidth, setTaskComponentWidth] = useLocalStorage(
     "taskComponentWidth",
     DEFAULT_WIDTH
-    );
-    const [showTasksAreSaved, setShowTasksAreSaved] = useLocalStorage("showTasksAreSaved", true);
+  );
+  const [showTasksAreSaved, setShowTasksAreSaved] = useLocalStorage("showTasksAreSaved", true);
 
   const numberOfTasks = tasks.filter(Boolean).length;
   const multipleTasks = numberOfTasks > 1;
@@ -189,7 +189,7 @@ export function Tasks() {
       <ul
         onMouseUp={handleResize}
         style={{ width: `${taskComponentWidth}px` }}
-        className="w-[300px] resize-x overflow-hidden rounded-2xl border border-trueBlack shadow-brutalist-dark dark:border-trueWhite dark:shadow-brutalist-light tiny:w-80 xs:w-96"
+        className="custom-scrollbar w-[300px] resize-x overflow-x-scroll rounded-2xl border border-trueBlack shadow-brutalist-dark dark:border-trueWhite dark:shadow-brutalist-light tiny:w-80 xs:w-96"
       >
         <DragDropContext onDragEnd={handleDragEnd} onDragStart={() => setSomeDragIsHappening(true)}>
           <Droppable droppableId="tasksList">

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,15 @@ input {
   /* we need this to have decent input borders on iOS, ignore warning */
   -webkit-border-radius: 0px;
 }
+
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  /* Your custom styles for the scrollbar track */
+  visibility: hidden;
+  position: relative;
+  bottom: 1px;
+}
+ 
+.custom-scrollbar::-webkit-scrollbar {
+  width: 0px; /* Width of the entire scrollbar */
+}


### PR DESCRIPTION
Fixes #66 

This adds a small CSS fix for the resize bug on Safari.
The crux of this issue is that Safari won't allow resizable elements with hidden overflow. Changing the overflow fixes that but comes with a small tradeoff: browsers will show the horizontal scrollbar. 
This PR prevents the visual uglyness of that, hiding said scrollbar but it's height is kept as long as overflow-x:scroll is used, which is a dependency for the resize handler

A long term solution is to look for programatic, likely js based ways to do it.